### PR TITLE
Add support for markdown files

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,3 +12,4 @@ python_version = "3.5"
 [packages]
 sphinx = "*"
 sphinx-rtd-theme = "*"
+recommonmark = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2cadd3e109922db8b9c63a1f6bbee016f15ebe0932de33c94e351fb6f7c0ee3d"
+            "sha256": "34337a5271a25ed7ad39f9b66b7b65d527783f2892c43c1f2a0f60f611b91841"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -43,6 +43,12 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "commonmark": {
+            "hashes": [
+                "sha256:34d73ec8085923c023930dfc0bcd1c4286e28a2a82de094bb72fabcc0281cbe5"
+            ],
+            "version": "==0.5.4"
         },
         "docutils": {
             "hashes": [
@@ -111,6 +117,14 @@
                 "sha256:c06425302f2cf668f1bba7a0a03f3c1d34d4ebeef2c72003da308b3947c7f749"
             ],
             "version": "==2018.4"
+        },
+        "recommonmark": {
+            "hashes": [
+                "sha256:6e29c723abcf5533842376d87c4589e62923ecb6002a8e059eb608345ddaff9d",
+                "sha256:cd8bf902e469dae94d00367a8197fb7b81fcabc9cfb79d520e0d22d0fbeaa8b7"
+            ],
+            "index": "pypi",
+            "version": "==0.4.0"
         },
         "requests": {
             "hashes": [

--- a/source/conf.py
+++ b/source/conf.py
@@ -54,7 +54,7 @@ templates_path = ['_templates']
 # You can specify multiple suffix as a list of string:
 #
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 
 # The master toctree document.
 master_doc = 'index'
@@ -191,3 +191,8 @@ texinfo_documents = [
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = True
+
+# Markdown support
+source_parsers = {
+   '.md': 'recommonmark.parser.CommonMarkParser',
+}


### PR DESCRIPTION
Uses the `recommonmark` plugin as described here: http://www.sphinx-doc.org/en/master/markdown.html

Tested and working locally and on fork