### PR TITLE
Argument mismatch

### DIFF
--- a/source/tutorial/7_implement.rst
+++ b/source/tutorial/7_implement.rst
@@ -327,7 +327,7 @@ We would expect to keep 1 contig and filter out the other.
             'min_length': 200000,
             'max_length': 6000000
         }
-        result = self.serviceImpl.run_{username}ContigFilter_max(self.ctx, self.wsName, params)
+        result = self.serviceImpl.run_{username}ContigFilter_max(self.ctx, params)
         self.assertEqual(result[0]['n_total'], 2)
         self.assertEqual(result[0]['n_remaining'], 1)
 
@@ -339,7 +339,7 @@ We would expect to keep 1 contig and filter out the other.
             'min_length': 100000,
             'max_length': 4000000
         }
-        result = self.serviceImpl.run_{username}ContigFilter_max(self.ctx, self.wsName, params)
+        result = self.serviceImpl.run_{username}ContigFilter_max(self.ctx, params)
         self.assertEqual(result[0]['n_total'], 2)
         self.assertEqual(result[0]['n_remaining'], 1)
 


### PR DESCRIPTION
In "Add real tests" the tests call the "run_{username}ContigFilter_max" function with an argument of self.wsName which is an extra argument to those defined in the function def at the beginning of the Implement tutorial:  "def run_{username}ContigFilter_max(self, ctx, params):". 
Upon removing the extra arg the tests ran fine. In addition "self.wsName" is defined in the "params" so there is no reason to pass it as an arg since it's already passing with the params. Thus, no functionality in the app changes.