### PR TITLE
Updating docs on building kb-sdk from source

### DIFF
--- a/source/howtos/edit_your_dockerfile.rst
+++ b/source/howtos/edit_your_dockerfile.rst
@@ -9,13 +9,13 @@ A helpful resource is the |bestPractices_link| guide.
 
 The first two lines of the Dockerfile look something like:
 
-:: 
+::
 
-    FROM kbase/kbase:sdkbase2.latest
+    FROM kbase/sdkbase2:latest
     MAINTAINER KBase Developer
 
 Change  ``KBase Developer`` to be the email address of the person
-who will be responsible for the upkeep of the module. 
+who will be responsible for the upkeep of the module.
 
 The base KBase Docker image contains a KBase Ubuntu image with the
 dependencies necessary JSON-RPC server in the supported language, as

--- a/source/howtos/manual_build.rst
+++ b/source/howtos/manual_build.rst
@@ -3,28 +3,27 @@ Manually building the SDK
 
 .. warning::
 
-    The recommended installation option is to run the |container_link|. 
+    The recommended installation option is to run the |container_link|.
 
 
-Java JDK 7+
+Java JDK 8
 '''''''''''
 
-|oracle_link| 
+|oracle_link|
 
 After downloading and installing the JDK, set your ``JAVA_HOME``
 environment variable to point to your JDK installation. If you're not
 sure where that is, on a Mac, the command ``/usr/libexec/java_home``
 should tell you and on Linux, ``readlink -f $(which javac)`` will provide
 the installed location of the javac, which you can use to find the base
-directory of the installation. On a Mac you can set the variable like
-so:
+directory of the installation. On a Mac you can set the variable like so:
 
 ::
 
     # for bash
     export JAVA_HOME=`/usr/libexec/java_home`
     # for tcsh/csh
-    setenv JAVA_HOME `/usr/libexec/java_home`  
+    setenv JAVA_HOME `/usr/libexec/java_home`
 
 You should probably add this command to the end of your
 ``~/.bash_profile`` or ``~/.bashrc`` file so it is always set when you start
@@ -33,9 +32,9 @@ a terminal.
 Apache Ant
 ''''''''''
 
-|ant_link| 
+|ant_link|
 
-|antapache_link| 
+|antapache_link|
 
 The easiest way to install Ant on a Mac is probably to use a package
 manager like |brew_link| , which allows you to install
@@ -53,7 +52,6 @@ here. All commands that follow are assuming you are using a UNIX shell.
 
     cd <working_dir>
     git clone https://github.com/kbase/kb_sdk
-    git clone https://github.com/kbase/jars
     cd kb_sdk
     make bin  # or "make" to compile from scratch
 
@@ -78,27 +76,12 @@ available in the terminal with command completion.
 Test installation
 ^^^^^^^^^^^^^^^^^
 
-To make sure you installed the SDK successfully, type kb-sdk help
-
-Download the KBase SDK base Docker image
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-KBase modules run in Docker containers. Docker containers are built on
-top of existing base images. KBase has a public base image that includes
-a number of installed runtimes, some basic bioinformatics tools, and
-other KBase specific tools. To run this locally, you will need to
-download and build the KBase SDK base image. There is a Makefile target
-that does most of the work for you:
+To make sure you have built and installed the SDK successfully, type ``kb-sdk help`` and ``kb-sdk version``. Check that the version matches that declared in the line in ``src/java/us/kbase/mobu/ModuleBuilder.java`` that looks like this:
 
 ::
 
-    make sdkbase
+    public static final String VERSION = "1.x.x";
 
-You will get a failure if the Docker daemon is not running when you
-invoke the above command. See |dependencies_link| for guidance.
-
-The image is fairly large, so it will take some time to run and build
-the image... External links
 
 .. External links
 
@@ -122,10 +105,10 @@ the image... External links
 
 .. |dependencies_link| raw:: html
 
-   <a href="../tutorial/dependencies.html">Install SDK Dependencies -Docker </a>
+   <a href="../tutorial/dependencies.html">Install SDK Dependencies - Docker </a>
 
 .. |container_link| raw:: html
 
-   <a href="../tutorial/install.html">SDK as a Docker container.</a>
+   <a href="../tutorial/install.html">SDK as a Docker container</a>
 
 

--- a/source/tutorial/1_dependencies.rst
+++ b/source/tutorial/1_dependencies.rst
@@ -5,15 +5,15 @@ Dependencies & Prerequisites
 System Dependencies:
 
 * Mac OS X 10.8+ (Docker requires this) or Linux.  kb-sdk does not run natively in Windows
-* (Not required for Docker-based installation) Java JRE 7 or 8 (9 is currently incompatible) |JAVAjre_link|
-* (Mac only) Xcode  |Xcode_link|
-* git  |gitscm_link|
+* Xcode (Mac only) |Xcode_link|
+* git |gitscm_link|
 * Docker |docker_link| (for local testing)
 * At least 20 GB free on your hard drive to install Docker, Xcode, Java JRE, etc.
+* (Not required for Docker-based installation) Java JRE 7 or 8 (9 is currently incompatible) |JAVAjre_link|
 
 We recommend using Mac OS X 10.8+ or Linux for SDK development. Windows development is not currently supported.  If you are running Windows or do not want to develop on your local machine, we recommend using |virtualbox_link| and installing Ubuntu 14+.
 
-Xcode or the Xcode Command Line Tools will install some standard terminal commands like `make` and `git` that are necessary for building the KBase SDK and your module code.  |Xcode_link| 
+Xcode or the Xcode Command Line Tools will install some standard terminal commands like `make` and `git` that are necessary for building the KBase SDK and your module code.  |Xcode_link|
 
 The git homepage can be found at |gitscm_link|. On Ubuntu, install it with ``sudo apt-get install git``.
 
@@ -33,7 +33,7 @@ When you run an app in a narrative, it runs in a docker container on KBase's ser
 
 .. External links
 
-.. |JAVAJre_link| raw:: html 
+.. |JAVAJre_link| raw:: html
 
    <a href="http://www.oracle.com/technetwork/java/javase/downloads/index.html" target="_blank">http://www.oracle.com/technetwork/java/javase/downloads/index.html</a>
 


### PR DESCRIPTION
This involves:
- update references to the kbase app base image to refer to `kbase/sdkbase2:latest` instead of `kbase/kbase:sdkbase2.latest`;
- change Java reference to Java 8 as Java 7+ is now difficult to get hold of;
- remove references to building the sdkbase image from scratch; the base images are now on dockerhub instead.