### PR TITLE
See https://github.com/sphinx-doc/sphinx/issues/7747

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -18,7 +18,7 @@
 
 
 def setup(app):
-    app.add_stylesheet('css/custom.css')
+    app.add_css_file('css/custom.css')
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Fix for
```
Exception occurred:
  File "/kb_sdk_docs/source/conf.py", line 21, in setup
    app.add_stylesheet('css/custom.css')
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'
The full traceback has been saved in /var/folders/hr/rgzsvs593tbfkw4bcstccb7m0000gn/T/sphinx-err-swb6qa6j.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https
```