### PR TITLE
DEVOPS-1821 Update error messages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,7 +9,7 @@ python_version = "3.7"
 [packages]
 sphinx-autobuild = "*"
 sphinx = "*"
-sphinx-rtd-theme = "*"
+sphinx_rtd_theme = "*"
 recommonmark = "*"
 rstcheck = "*"
 

--- a/source/conf.py
+++ b/source/conf.py
@@ -18,7 +18,7 @@
 
 
 def setup(app):
-    app.add_stylesheet('css/custom.css')
+    app.add_css_file('css/custom.css')
 
 # -- Project information -----------------------------------------------------
 

--- a/source/howtos/workspace.rst
+++ b/source/howtos/workspace.rst
@@ -13,7 +13,7 @@ You can download the Workspace client by running the following inside an SDK mod
 Retrieving workspace object metadata
 ---------------------------------------
 
-If you don't want to retrieve the entire object, and just want information about it, the most efficient way is to use the ``ws.get_object_info`` function. To read more about the available functions, see the  |Workspace_link|.
+If you don't want to retrieve the entire object, and just want information about it, the most efficient way is to use the ``ws.get_object_info3`` function. To read more about the available functions, see the  |Workspace_link|.
 
 *Initialize the workspace client and get an object's information by reference*
 
@@ -25,8 +25,9 @@ If you don't want to retrieve the entire object, and just want information about
     self.token = config["KB_AUTH_TOKEN"]
     self.ws = Workspace(self.ws_url, token=self.token)
     obj_ref = "your/object/reference"
-    object_info = self.ws.get_object_info([{"ref": obj_ref}])[0]
-    object_type = object_info[2] #this could be KBaseGenomes.Genome-8.3
+    object_info = self.ws.get_object_info3([{"ref": obj_ref}])[0]
+    object_type_full = object_info[2] # This could be KBaseGenomes.Genome-8.3
+    object_type = object_type_full.split('-')[0] # This would be KBaseGenomes.Genome
 
 
 How to use the Workspace Client in the narrative

--- a/source/references/troubleshooting.rst
+++ b/source/references/troubleshooting.rst
@@ -51,14 +51,14 @@ Having trouble getting Docker working on Mac
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It may be that your Docker installation may be incorrect, out of date,
-or the daemon may not have been started. Please see |dockerMac_link| 
+or the daemon may not have been started. Please see |dockerMac_link|
 
 
 Having trouble getting Docker working on Linux
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 It may be that your Docker installation may be incorrect, out of date,
-or the daemon may not have been started. Please see |dockerLinux_link| 
+or the daemon may not have been started. Please see |dockerLinux_link|
 
 
 Getting Java-related errors trying to run kb-sdk
@@ -107,7 +107,7 @@ If you get an error on OSX as follows:
 
 Reinstall the latest version of the KBase SDK
 
-* Follow instructions at https://kbase.github.io/kb_sdk_docs/tutorial/2_install.html 
+* Follow instructions at https://kbase.github.io/kb_sdk_docs/tutorial/2_install.html
 * Don't forget to generate the new `kb-sdk` executable
 
 
@@ -167,21 +167,58 @@ can increase the amount of memory available to the containers.
 
     Advanced preferences in Docker for OS X.
 
-Error Messages
-^^^^^^^^^^^^^^
-*Error*: ``KeyError: 'getpwuid()' uid not found: '``
+Error Messages and Solutions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-*Solution*: Try changing the user flag in ``run_tests.sh``, ``run_bash.sh``, and ``run_subjobs.sh`` (if available) in the ``test_local`` directory to ``--user 0``. Alternatively, remove that flag altogether.
+Error: :code:`KeyError: 'getpwuid()' uid not found`
+----------------------------------------------
+This error occurs when host user IDs (UIDs) do not match the container’s UIDs. The user ID is stored in your :code:`~/.kbsdk.cache`.
+Please clear out the cache with the command :code:`rm -rf ~/.kbsdk.cache` and try again. Otherwise try the following:
 
-*Error*: ``Can't find image [test/<your_module_name>:latest].`` 
-``Here is 'docker images' output: Cannot connect to the Docker daemon.``
-``Is the docker daemon running on this host?``
+Solution: Modify the UID in the test scripts
+"""""""""
 
-*Solution*: Run the following code snippet `docker run -it -v /var/run/docker.sock:/run/docker.sock alpine chmod g+w /run/docker.sock`
+1. Modify the following scripts in the `test_local` directory:
+
+- `run_tests.sh`
+- `run_bash.sh`
+- `run_subjobs.sh`
+
+2. Change the user flag to :code:`--user 0` to run as root, which should bypass the UID issues:
+
+- Example, change :code:`./run_tests.sh --user $(id -u)` to :code:`./run_tests.sh --user 0`.
+
+3. If the problem persists, consider removing the :code:`--user` flag altogether.
 
 
+Error: :code:`Can't find image [test/<your_module_name>:latest]`
+-----------------------------------------------------------------
 
+.. code-block:: bash
 
+    Error: "Can't find image [test/<your_module_name>:latest]
+    Here is 'docker images' output: Cannot connect to the Docker daemon.
+    Is the docker daemon running on this host?
+
+This error indicates that Docker is either not running or not reachable, which prevents Docker commands from executing properly.
+
+Solution: Fix Docker Daemo Socket Permissions
+"""""""""
+
+1. Ensure that the Docker daemon is running on your host.
+
+2. Modify the permissions of the Docker socket to allow group write access, which should resolve connection issues :code:`docker run -it -v /var/run/docker.sock:/var/run/docker.sock alpine chmod g+w /var/run/docker.sock`
+
+3. Clear your `kb_sdk` cache with the command :code:`rm -rf ~/.kbsdk.cache` and try running your `kb-sdk` command again.
+
+Error: :code:`Error response from daemon: client version 1.23 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version`
+-----------------------------------------------------------------
+
+Solution: Don't use docker desktop > 1.2.3
+"""""""""
+
+1. :code:`kb-sdk` is not supported on new Docker Desktop versions. If you encounter this error, downgrade your Docker Desktop to version 4.2.4 or lower.
+2. Alternatively, you can use other docker tools like Rancher Desktop, Podman, or Colima
 
 
 .. External links

--- a/source/references/troubleshooting.rst
+++ b/source/references/troubleshooting.rst
@@ -218,7 +218,7 @@ Error: :code:`Error response from daemon: client version 1.23 is too old. Minimu
 Solution: Downgrade to a supported Docker Desktop version
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-1. :code:`kb-sdk` is not supported on new Docker Desktop versions. If you encounter this error, downgrade your Docker Desktop to version 4.2.4 or lower.
+1. :code:`kb-sdk` is not supported on new Docker Desktop versions. If you encounter this error, downgrade your Docker Desktop to version 4.24.0 or lower.
 2. Alternatively, you can use other Docker tools like |rancherDesktop_link|, |podman_link|, or |colima_link|.
 
 .. External links

--- a/source/references/troubleshooting.rst
+++ b/source/references/troubleshooting.rst
@@ -214,12 +214,11 @@ Solution: Fix Docker Daemo Socket Permissions
 Error: :code:`Error response from daemon: client version 1.23 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version`
 -----------------------------------------------------------------
 
-Solution: Don't use docker desktop > 1.2.3
+Solution: Downgrade to a supported Docker Desktop version
 """""""""
 
 1. :code:`kb-sdk` is not supported on new Docker Desktop versions. If you encounter this error, downgrade your Docker Desktop to version 4.2.4 or lower.
-2. Alternatively, you can use other docker tools like Rancher Desktop, Podman, or Colima
-
+2. Alternatively, you can use other Docker tools like |rancherDesktop_link|, |podman_link|, or |colima_link|.
 
 .. External links
 
@@ -227,25 +226,32 @@ Solution: Don't use docker desktop > 1.2.3
 
    <a href="../howtos/create_a_report.html" target="_blank">Creating a report </a>
 
- https://github.com/kbase/kb\_sdk/blob/master/doc/kb\_sdk\_dependencies.md
-
 .. |dependencies_link| raw:: html
 
-   <a href="https://github.com/kbase/kb_sdk/blob/master/doc/test_dependencies.md" target="_blank">https://github.com/kbase/kb_sdk/blob/master/doc/test_dependencies.md</a>
-
+   <a href="https://github.com/kbase/kb_sdk/blob/master/doc/test_dependencies.md" target="_blank">Test Dependencies</a>
 
 .. |dockerMac_link| raw:: html
 
-   <a href="https://docs.docker.com/mac/" target="_blank">https://docs.docker.com/mac/</a>
+   <a href="https://docs.docker.com/mac/" target="_blank">Docker for Mac</a>
 
 .. |dockerLinux_link| raw:: html
 
-   <a href="https://docs.docker.com/mac/" target="_blank">https://docs.docker.com/linux/</a>
+   <a href="https://docs.docker.com/linux/" target="_blank">Docker for Linux</a>
+
+.. |rancherDesktop_link| raw:: html
+
+   <a href="https://rancherdesktop.io/" target="_blank">Rancher Desktop</a>
+
+.. |podman_link| raw:: html
+
+   <a href="https://podman.io/" target="_blank">Podman</a>
+
+.. |colima_link| raw:: html
+
+   <a href="https://github.com/abiosoft/colima" target="_blank">Colima</a>
 
 .. Internal links
 
 .. |installSDK_link| raw:: html
 
    <a href="../tutorial/install.html">Install SDK Dependencies - Docker </a>
-
-

--- a/source/references/troubleshooting.rst
+++ b/source/references/troubleshooting.rst
@@ -224,7 +224,7 @@ Error: client version 1.23 is too old.
 Solution: Downgrade to a supported Docker Desktop version
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-1. :code:`kb-sdk` is not supported on new Docker Desktop versions. If you encounter this error, downgrade your Docker Desktop to version 4.2.4 or lower.
+1. :code:`kb-sdk` is not supported on new Docker Desktop versions. If you encounter this error, downgrade your Docker Desktop to version 4.24.0 or lower.
 2. Alternatively, you can use other Docker tools like |rancherDesktop_link|, |podman_link|, or |colima_link|.
 
 .. External links

--- a/source/references/troubleshooting.rst
+++ b/source/references/troubleshooting.rst
@@ -212,13 +212,19 @@ Solution: Fix Docker Daemon Socket Permissions
 
 3. Clear your `kb_sdk` cache with the command :code:`rm -rf ~/.kbsdk.cache` and try running your `kb-sdk` command again.
 
-Error: :code:`Error response from daemon: client version 1.23 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version`
----------------------------------------------------------------------------------------------------------------------------------------------------------------
+Error: client version 1.23 is too old.
+""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+    Error response from daemon: client version 1.23 is too old.
+    Minimum supported API version is 1.24, please upgrade your client to a newer version
+
 
 Solution: Downgrade to a supported Docker Desktop version
 """""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-1. :code:`kb-sdk` is not supported on new Docker Desktop versions. If you encounter this error, downgrade your Docker Desktop to version 4.24.0 or lower.
+1. :code:`kb-sdk` is not supported on new Docker Desktop versions. If you encounter this error, downgrade your Docker Desktop to version 4.2.4 or lower.
 2. Alternatively, you can use other Docker tools like |rancherDesktop_link|, |podman_link|, or |colima_link|.
 
 .. External links

--- a/source/references/troubleshooting.rst
+++ b/source/references/troubleshooting.rst
@@ -228,15 +228,15 @@ Solution: Downgrade to a supported Docker Desktop version
 
 .. |dependencies_link| raw:: html
 
-   <a href="https://github.com/kbase/kb_sdk/blob/master/doc/test_dependencies.md" target="_blank">Test Dependencies</a>
+   <a href="https://github.com/kbase/kb_sdk/blob/master/doc/test_dependencies.md" target="_blank">https://github.com/kbase/kb_sdk/blob/master/doc/test_dependencies.md</a>
 
 .. |dockerMac_link| raw:: html
 
-   <a href="https://docs.docker.com/mac/" target="_blank">Docker for Mac</a>
+   <a href="https://docs.docker.com/mac/" target="_blank">https://docs.docker.com/mac/</a>
 
 .. |dockerLinux_link| raw:: html
 
-   <a href="https://docs.docker.com/linux/" target="_blank">Docker for Linux</a>
+   <a href="https://docs.docker.com/linux/" target="_blank">https://docs.docker.com/linux/</a>
 
 .. |rancherDesktop_link| raw:: html
 

--- a/source/references/troubleshooting.rst
+++ b/source/references/troubleshooting.rst
@@ -213,7 +213,7 @@ Solution: Fix Docker Daemon Socket Permissions
 3. Clear your `kb_sdk` cache with the command :code:`rm -rf ~/.kbsdk.cache` and try running your `kb-sdk` command again.
 
 Error: client version 1.23 is too old.
-""""""""""""""""""""""""""""""""""""""
+--------------------------------------
 
 .. code-block:: bash
 

--- a/source/references/troubleshooting.rst
+++ b/source/references/troubleshooting.rst
@@ -176,7 +176,7 @@ This error occurs when host user IDs (UIDs) do not match the container’s UIDs.
 Please clear out the cache with the command :code:`rm -rf ~/.kbsdk.cache` and try again. Otherwise try the following:
 
 Solution: Modify the UID in the test scripts
-"""""""""
+""""""""""""""""""""""""""""""""""""""""""""
 
 1. Modify the following scripts in the `test_local` directory:
 
@@ -202,20 +202,21 @@ Error: :code:`Can't find image [test/<your_module_name>:latest]`
 
 This error indicates that Docker is either not running or not reachable, which prevents Docker commands from executing properly.
 
-Solution: Fix Docker Daemo Socket Permissions
-"""""""""
+Solution: Fix Docker Daemon Socket Permissions
+""""""""""""""""""""""""""""""""""""""""""""""
 
 1. Ensure that the Docker daemon is running on your host.
 
-2. Modify the permissions of the Docker socket to allow group write access, which should resolve connection issues :code:`docker run -it -v /var/run/docker.sock:/var/run/docker.sock alpine chmod g+w /var/run/docker.sock`
+2. Modify the permissions of the Docker socket to allow group write access, which should resolve connection issues
+:code:`docker run -it -v /var/run/docker.sock:/var/run/docker.sock alpine chmod g+w /var/run/docker.sock`
 
 3. Clear your `kb_sdk` cache with the command :code:`rm -rf ~/.kbsdk.cache` and try running your `kb-sdk` command again.
 
 Error: :code:`Error response from daemon: client version 1.23 is too old. Minimum supported API version is 1.24, please upgrade your client to a newer version`
------------------------------------------------------------------
+---------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 Solution: Downgrade to a supported Docker Desktop version
-"""""""""
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 1. :code:`kb-sdk` is not supported on new Docker Desktop versions. If you encounter this error, downgrade your Docker Desktop to version 4.2.4 or lower.
 2. Alternatively, you can use other Docker tools like |rancherDesktop_link|, |podman_link|, or |colima_link|.


### PR DESCRIPTION
* This updates/reformats the common error messages and tells users to downgrade their docker
* This also includes changes to the pipfile that allows for building (see https://github.com/kbase/kb_sdk_docs/pull/78)
* You can copy paste to https://rsted.info.ucl.ac.be/ or press "View File" to see the rendered file